### PR TITLE
xwayland: relax focus checks for clipboard bridge ownership

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 fix-dnd-handling-during-popup-interactions.patch
+xclip-read-clipboard-content.patch

--- a/debian/patches/xclip-read-clipboard-content.patch
+++ b/debian/patches/xclip-read-clipboard-content.patch
@@ -1,0 +1,46 @@
+Index: wlroots/xwayland/selection/incoming.c
+===================================================================
+--- wlroots.orig/xwayland/selection/incoming.c
++++ wlroots/xwayland/selection/incoming.c
+@@ -463,14 +463,12 @@ void xwm_handle_selection_notify(struct
+ 			xwm_selection_transfer_destroy(transfer);
+ 		}
+ 	} else if (event->target == xwm->atoms[TARGETS]) {
+-		// No xwayland surface focused, deny access to clipboard
+-		if (xwm->focus_surface == NULL) {
+-			wlr_log(WLR_DEBUG, "denying write access to clipboard: "
+-				"no xwayland surface focused");
+-			return;
+-		}
+-
+-		// This sets the Wayland clipboard (by calling wlr_seat_set_selection)
++		// This sets the Wayland clipboard (by calling wlr_seat_set_selection).
++		// We do not gate this on focus_surface: an X11 client that explicitly
++		// called XSetSelectionOwner has already declared its intent to own the
++		// clipboard. Requiring an Xwayland surface to be focused here would
++		// prevent headless X11 tools (e.g. xclip, xsel) from ever being able
++		// to bridge their content to Wayland clients.
+ 		xwm_selection_get_targets(selection);
+ 	} else if (transfer) {
+ 		xwm_selection_transfer_get_data(transfer);
+Index: wlroots/xwayland/selection/outgoing.c
+===================================================================
+--- wlroots.orig/xwayland/selection/outgoing.c
++++ wlroots/xwayland/selection/outgoing.c
+@@ -413,8 +413,15 @@ void xwm_handle_selection_request(struct
+ 	bool dnd_allowed = selection == &xwm->dnd_selection
+ 		&& (xwm->drag_focus != NULL || xwm->drop_focus != NULL);
+ 
++	// When wlroots itself owns the selection (Wayland→X11 bridge), access
++	// control was already applied at the Wayland compositor level. Denying
++	// X11 clients here defeats the purpose of the clipboard bridge and causes
++	// clipboard managers and X11 tools (xclip, xsel, etc.) to be unable to
++	// read Wayland-sourced clipboard content.
++	bool wayland_bridge = (selection->owner == selection->window);
++
+ 	// No xwayland surface focused, deny access to clipboard
+-	if (xwm->focus_surface == NULL && !dnd_allowed) {
++	if (xwm->focus_surface == NULL && !dnd_allowed && !wayland_bridge) {
+ 		if (wlr_log_get_verbosity() >= WLR_DEBUG) {
+ 			char *selection_name = xwm_get_atom_name(xwm, selection->atom);
+ 			wlr_log(WLR_DEBUG, "denying read access to selection %u (%s): "


### PR DESCRIPTION
wlroots uses X11 selections as a bridge between Wayland and Xwayland clipboard clients. However, two focus-based access checks prevented clipboard synchronization from working correctly in common headless X11 scenarios.